### PR TITLE
Fix panic when reading incomplete blocks from underlying reader

### DIFF
--- a/openssl.go
+++ b/openssl.go
@@ -13,7 +13,10 @@ import (
 	"io"
 )
 
-const opensslSaltLength = 8
+const (
+	opensslSaltHeader = "Salted__" // OpenSSL salt is always this string + 8 bytes of actual salt
+	opensslSaltLength = 8
+)
 
 // ErrInvalidSalt is returned when a salt with a length of != 8 byte is passed
 var ErrInvalidSalt = errors.New("salt needs to have exactly 8 byte")
@@ -58,7 +61,7 @@ func (o Creds) equals(i Creds) bool {
 // New instanciates and initializes a new OpenSSL encrypter
 func New() *OpenSSL {
 	return &OpenSSL{
-		openSSLSaltHeader: "Salted__", // OpenSSL salt is always this string + 8 bytes of actual salt
+		openSSLSaltHeader: opensslSaltHeader,
 	}
 }
 

--- a/stream_test.go
+++ b/stream_test.go
@@ -2,11 +2,25 @@ package openssl
 
 import (
 	"bytes"
+	"crypto/aes"
 	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+type onlyOneByteReader struct {
+	size int
+	r    io.Reader
+}
+
+func (o *onlyOneByteReader) Read(b []byte) (int, error) {
+	if len(b) == 0 {
+		return 0, nil
+	}
+
+	return o.r.Read(b[:o.size])
+}
 
 func TestReader(t *testing.T) {
 	o := New()
@@ -18,9 +32,15 @@ func TestReader(t *testing.T) {
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(nil)
-	_, err = io.Copy(buf, NewReader(bytes.NewReader(data), pass, BytesToKeyMD5))
-	require.NoError(t, err)
-	require.Equal(t, buf.Bytes(), plaintext)
+	bytesBuf := make([]byte, aes.BlockSize+1)
+
+	for i := 1; i <= aes.BlockSize+1; i++ {
+		buf.Reset()
+		r := &onlyOneByteReader{i, bytes.NewReader(data)}
+		_, err = io.CopyBuffer(buf, NewReader(r, pass, BytesToKeyMD5), bytesBuf)
+		require.NoError(t, err)
+		require.Equal(t, plaintext, buf.Bytes())
+	}
 }
 
 func TestWriter(t *testing.T) {


### PR DESCRIPTION
fix when read not block size data from underlying reader panic: crypto/cipher: input not full blocks